### PR TITLE
Fix No Image icon URL

### DIFF
--- a/src/renderer/components/Main.vue
+++ b/src/renderer/components/Main.vue
@@ -158,7 +158,7 @@
             size="125"
             tile
           >
-            <v-img :src="(uriInstallModData ? uriInstallModData.logo : null) || 'https://ficsit.app/static/assets/images/no_image.png'" />
+            <v-img :src="(uriInstallModData ? uriInstallModData.logo : null) || 'https://ficsit.app/images/no_image.webp'" />
           </v-avatar>
         </div>
       </v-card>

--- a/src/renderer/components/mod-details/ModDetailsInfo.vue
+++ b/src/renderer/components/mod-details/ModDetailsInfo.vue
@@ -198,7 +198,7 @@ export default {
       'inProgress',
     ]),
     icon() {
-      return this.mod.logo || 'https://ficsit.app/static/assets/images/no_image.png';
+      return this.mod.logo || 'https://ficsit.app/images/no_image.webp';
     },
     multiplayerSupport() {
       return this.mod.multiplayer_support || 'N/A';

--- a/src/renderer/components/mods-list/ModsListItem.vue
+++ b/src/renderer/components/mods-list/ModsListItem.vue
@@ -198,7 +198,7 @@ export default {
       return this.expandedModId === this.mod.mod_reference;
     },
     icon() {
-      return this.mod.logo || 'https://ficsit.app/static/assets/images/no_image.png';
+      return this.mod.logo || 'https://ficsit.app/images/no_image.webp';
     },
     isModInProgress() {
       return !!this.modProgress;


### PR DESCRIPTION
The URL for the icon when no app logo is set, now results in a 404 page causing a broken image to appear in mod list.

Updated the URL to the no_image.webp currently used on ficsit.app, https://ficsit.app/images/no_image.webp