### PR TITLE
Redact launcher friend names from FactoryGame.log (#231)

### DIFF
--- a/backend/app/debug_info.go
+++ b/backend/app/debug_info.go
@@ -122,7 +122,7 @@ func addFactoryGameLogs(writer *zip.Writer) {
 
 func getLogNameForInstall(install *common.Installation) string {
 	hash := sha256.Sum256([]byte(install.Path))
-	return fmt.Sprintf("FactoryGame_%s.log", hex.EncodeToString(hash[:])[:8])
+	return fmt.Sprintf("FactoryGame_%s_%s_%s_%s.log", install.Location, install.Branch, install.Type, hex.EncodeToString(hash[:])[:8])
 }
 
 func addMetadata(writer *zip.Writer) error {


### PR DESCRIPTION
Also includes more detailed log names in the zip. This still doesn't guarantee that the log is from that install though, ex. in the case of Epic and Steam being installed locally