### PR TITLE
fix(epic.go): Fix Epic Games Store appName detection

### DIFF
--- a/backend/installfinders/launchers/epic/epic.go
+++ b/backend/installfinders/launchers/epic/epic.go
@@ -103,28 +103,29 @@ func FindInstallationsEpic(epicManifestsPath string, launcher string, platform c
 			continue
 		}
 
-		branch, err := GetEpicBranch(epicManifest.MainGameAppName)
-		if err != nil {
-			// Some Epic installs appear to come in with a null MainGameAppName; fall back to AppName
-			branch, err = GetEpicBranch(epicManifest.AppName)
+		appName := epicManifest.MainGameAppName
+		if appName == "" {
+    		appName = epicManifest.AppName
 		}
+
+		branch, err := GetEpicBranch(appName)
 		if err != nil {
-			findErrors = append(findErrors, common.InstallFindError{
-				Path:  installLocation,
-				Inner: err,
-			})
-			continue
+    		findErrors = append(findErrors, common.InstallFindError{
+        		Path:  installLocation,
+        		Inner: err,
+    		})
+    		continue
 		}
 
 		installs = append(installs, &common.Installation{
-			Path:       filepath.Clean(installLocation),
-			Version:    version,
-			Type:       installType,
-			Location:   common.LocationTypeLocal,
-			Branch:     branch,
-			Launcher:   launcher,
-			LaunchPath: platform.LauncherCommand(epicManifest.MainGameAppName),
-			SavedPath:  savedPath,
+    		Path:       filepath.Clean(installLocation),
+    		Version:    version,
+    		Type:       installType,
+    		Location:   common.LocationTypeLocal,
+    		Branch:     branch,
+    		Launcher:   launcher,
+    		LaunchPath: platform.LauncherCommand(appName),
+    		SavedPath:  savedPath,
 		})
 	}
 


### PR DESCRIPTION
EGS's manifest for Satisfactory now has a blank MainGameAppName, so this uses AppName as a fallback.